### PR TITLE
Fixed division by zero bug. 

### DIFF
--- a/Saddam.py
+++ b/Saddam.py
@@ -124,7 +124,7 @@ def Monitor():
 	start = time.time()
 	while True:
 		try:
-			current = time.time() - start
+			current = time.time() - start or 1
 			bps = (nbytes*8)/current
 			pps = npackets/current
 			out = FMT.format(Calc(npackets, 1000), 


### PR DESCRIPTION
Solution for https://github.com/OffensivePython/Saddam/issues/3 
You can't divide by zero, so the failsafe is '1'.
